### PR TITLE
Bug Fix: Remove `--with-lua` flag

### DIFF
--- a/install-scripts/OSX/install-packages.sh
+++ b/install-scripts/OSX/install-packages.sh
@@ -16,7 +16,7 @@ if [[ $answer != "n" ]] && [[ $answer != "N" ]] ; then
     # The regular brew installable packages
     # ===
     brew install zsh
-    brew install vim --with-lua
+    brew install vim
     brew install tig
     brew install aspell
     brew install node


### PR DESCRIPTION
Installing vim with flags has been removed Homebrew/homebrew-core#34421